### PR TITLE
Protect credentials with HTTPS

### DIFF
--- a/lib/gowalla/client.rb
+++ b/lib/gowalla/client.rb
@@ -36,15 +36,21 @@ module Gowalla
     #
     # @return [Faraday::Connection]
     def connection
-      url = @access_token ? "https://api.gowalla.com" : "http://api.gowalla.com"
       params = {}
       params[:access_token] = @access_token if @access_token
-      @connection ||= Faraday::Connection.new(:url => url, :params => params, :headers => default_headers) do |builder|
+      @connection ||= Faraday::Connection.new(:url => api_url, :params => params, :headers => default_headers) do |builder|
         builder.adapter Faraday.default_adapter
         builder.use Faraday::Response::ParseJson
         builder.use Faraday::Response::Mashify
       end
 
+    end
+
+    # Provides the URL for accessing the API
+    #
+    # @return [String]
+    def api_url
+      authentication_credentials_provided? ? "https://api.gowalla.com" : "http://api.gowalla.com"
     end
 
     # Provides raw access to the OAuth2 Client
@@ -89,6 +95,10 @@ module Gowalla
         }
       end
 
+      # @private
+      def authentication_credentials_provided?
+        @api_key || @api_secret || @username || @access_token
+      end
 
   end
 

--- a/test/checkins_test.rb
+++ b/test/checkins_test.rb
@@ -8,7 +8,7 @@ class CheckinsTest < Test::Unit::TestCase
     end
 
     should "fetch info for a checkin" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/checkins/88", "checkin.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/checkins/88", "checkin.json")
       checkin = @client.checkin_info(88)
       checkin.spot.name.should == 'Movie Tavern'
       checkin.message.should == 'There sending us Back-- to the Future!'

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -10,6 +10,13 @@ class ClientTest < Test::Unit::TestCase
 
   end
 
+  context "when accessing the API anonymously" do
+    should "send requests unencrypted over plain HTTP" do
+      @client = Gowalla::Client.new
+      @client.api_url.should == 'http://api.gowalla.com'
+    end
+  end
+
   context "when using basic auth" do
     should "configure api_key, username, and password for easy access" do
 
@@ -22,10 +29,21 @@ class ClientTest < Test::Unit::TestCase
 
       @client = Gowalla::Client.new
 
-      stub_get('http://username:password@api.gowalla.com/trips', 'trips.json')
+      stub_get('https://username:password@api.gowalla.com/trips', 'trips.json')
       trips = @client.trips
 
       @client.username.should == 'username'
+    end
+    
+    should "use HTTPS to avoid sending password in plain text" do
+      Gowalla.configure do |config|
+        config.api_key = 'api_key'
+        config.username = 'username'
+        config.password = 'password'
+      end
+
+      @client = Gowalla::Client.new
+      @client.api_url.should == 'https://api.gowalla.com'
     end
 
     should "configure test mode" do
@@ -58,6 +76,10 @@ class ClientTest < Test::Unit::TestCase
       @client.oauth_client.id.should == 'api_key'
     end
 
+    should "use HTTPS to avoid sending credentials in plain text" do
+      @client.api_url.should == 'https://api.gowalla.com'
+    end
+    
     should "create an OAuth2 client" do
       @client.oauth_client.class.to_s.should == "OAuth2::Client"
     end

--- a/test/flags_test.rb
+++ b/test/flags_test.rb
@@ -8,7 +8,7 @@ class FlagsTest < Test::Unit::TestCase
     end
 
     should "retrieve a list of flags" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/flags", "flags.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/flags", "flags.json")
       flags = @client.list_flags
       flags.first.spot.name.should == 'Wild Gowallaby #1'
       flags.first.user.url.should == '/users/340897'
@@ -17,7 +17,7 @@ class FlagsTest < Test::Unit::TestCase
     end
 
     should "retrieve information about a specific flag" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/flags/1", "flag.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/flags/1", "flag.json")
       flag = @client.flag(1)
       flag.spot.name.should == 'Wild Gowallaby #1'
       flag.user.url.should == '/users/340897'
@@ -27,7 +27,7 @@ class FlagsTest < Test::Unit::TestCase
 
 
     should "retrieve flags associated with that spot" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/spots/1/flags", "flags.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/spots/1/flags", "flags.json")
       flags = @client.spot_flags(1)
       flags.first.spot.name.should == 'Wild Gowallaby #1'
       flags.first.user.url.should == '/users/340897'
@@ -36,7 +36,7 @@ class FlagsTest < Test::Unit::TestCase
     end
 
     should "set a flag on a specific spot" do
-      url = "http://pengwynn:0U812@api.gowalla.com/spots/1/flags/invalid"
+      url = "https://pengwynn:0U812@api.gowalla.com/spots/1/flags/invalid"
       FakeWeb.register_uri(:post, url, :body => '{"result": "flag created"}')
       response = @client.flag_spot(1, 'invalid', 'my problem description')
       response.result.should == 'flag created'

--- a/test/items_test.rb
+++ b/test/items_test.rb
@@ -8,7 +8,7 @@ class ItemsTest < Test::Unit::TestCase
     end
 
     should "retrieve information about a specific item" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/items/607583', 'item.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/items/607583', 'item.json')
       item = @client.item(607583)
       item.issue_number.should == 13998
       item.name.should == 'Sweets'
@@ -16,7 +16,7 @@ class ItemsTest < Test::Unit::TestCase
     end
 
     should "retrieve events associated with a specific item" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/items/607583/events', 'item_events.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/items/607583/events', 'item_events.json')
       events = @client.item_events(607583)
       events.first.spot.name = 'Jerusalem Bakery'
       events.first.user.first_name = 'Scott'

--- a/test/spots_test.rb
+++ b/test/spots_test.rb
@@ -8,20 +8,20 @@ class SpotsTest < Test::Unit::TestCase
     end
 
     should "Retrieve a list of spots within a specified distance of a location" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/spots?lat=%2B33.237593417&lng=-96.960559033&radius=50", "spots.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/spots?lat=%2B33.237593417&lng=-96.960559033&radius=50", "spots.json")
       spots = @client.list_spots(:lat => 33.237593417, :lng => -96.960559033, :radius => 50)
       spots.first.name.should == 'Gnomb Bar'
       spots.first.radius_meters.should == 50
     end
 
     should "Retrieve a list of spots within a specified bounds" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/spots?sw=%2839.25565142103586%2C%20-8.717308044433594%29&nw=%2839.31411296530539%2C%20-8.490715026855469%29", "spots.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/spots?sw=%2839.25565142103586%2C%20-8.717308044433594%29&nw=%2839.31411296530539%2C%20-8.490715026855469%29", "spots.json")
       spots = @client.list_spots(:sw => "(39.25565142103586, -8.717308044433594)", :nw => "(39.31411296530539, -8.490715026855469)")
       spots.first.name.should == 'Gnomb Bar'
     end
 
     should "Retrieve information about a specific spot" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/spots/18568', 'spot.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/spots/18568', 'spot.json')
       spot = @client.spot(18568)
       spot.name.should == "Wahoo's"
       spot.twitter_username.should == 'Wahoos512'
@@ -29,21 +29,21 @@ class SpotsTest < Test::Unit::TestCase
     end
 
     should "retrieve a list of check-ins at a particular spot. Shows only the activity that is visible to a given user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/spots/452593/events', 'events.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/spots/452593/events', 'events.json')
       events = @client.spot_events(452593)
       events.first[:type].should == 'checkin'
       events.first.user.last_name.should == 'Mack'
     end
 
     should "retrieve a list of items available at a particular spot" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/spots/18568/items', 'items.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/spots/18568/items', 'items.json')
       items = @client.spot_items(18568)
       items.first.issue_number.should == 27868
       items.first.name.should == 'Bowl of Noodles'
     end
 
     should "lists all spot categories" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/categories", "categories.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/categories", "categories.json")
       categories = @client.categories
       categories.size.should == 9
       categories.first.name.should == 'Architecture & Buildings'
@@ -53,13 +53,13 @@ class SpotsTest < Test::Unit::TestCase
     end
 
     should "retrieve information about a specific category" do
-      stub_get("http://pengwynn:0U812@api.gowalla.com/categories/1", "category.json")
+      stub_get("https://pengwynn:0U812@api.gowalla.com/categories/1", "category.json")
       category = @client.category(1)
       category.name.should == 'Coffee Shop'
     end
 
     should "retrieve photos taken at a spot" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/spots/18568/photos', 'photos.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/spots/18568/photos', 'photos.json')
       photos = @client.spot_photos(18568)
       #photos.first.type.should == 'photo'
       photos.first.photo_urls.square_50.should == 'http://static.gowalla.com/photos/912078_square_50.jpg'

--- a/test/trips_test.rb
+++ b/test/trips_test.rb
@@ -8,14 +8,14 @@ class TripsTest < Test::Unit::TestCase
     end
 
     should "retrieve a list of trips" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/trips', 'trips.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/trips', 'trips.json')
       trips = @client.trips
       trips.first.name.should == 'London Pub Crawl'
       trips.first.spots.first.url.should == '/spots/164009'
     end
 
     should "retrieve information about a specific trip" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/trips/1', 'trip.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/trips/1', 'trip.json')
       trip = @client.trip(1)
       trip.creator.last_name.should == 'Gowalla'
       trip.map_bounds.east.should == -63.457031

--- a/test/users_test.rb
+++ b/test/users_test.rb
@@ -8,21 +8,21 @@ class UsersTest < Test::Unit::TestCase
     end
 
     should "retrive information about the current user if no user specified" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/pengwynn', 'user.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/pengwynn', 'user.json')
       user = @client.user
       user.bio.should == "CTO & co-founder of Gowalla. Ruby/Cocoa/JavaScript developer. Game designer. Author. Indoorsman."
       user.stamps_count.should == 506
     end
 
     should "retrieve information about a specific user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco', 'user.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco', 'user.json')
       user = @client.user('sco')
       user.bio.should == "CTO & co-founder of Gowalla. Ruby/Cocoa/JavaScript developer. Game designer. Author. Indoorsman."
       user.stamps_count.should == 506
     end
 
     should "retrieve a list of the stamps the user has collected" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/1707/stamps?limit=20', 'stamps.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/1707/stamps?limit=20', 'stamps.json')
       stamps = @client.stamps(1707)
       stamps.size.should == 20
       stamps.first.spot.name.should == "Muck-N-Dave's Texas BBQ"
@@ -30,7 +30,7 @@ class UsersTest < Test::Unit::TestCase
     end
 
     should "retrieve a list of spots the user has visited most often" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/1707/top_spots', 'top_spots.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/1707/top_spots', 'top_spots.json')
       top_spots = @client.top_spots(1707)
       top_spots.size.should == 10
       top_spots.first.name.should == 'Juan Pelota Cafe'
@@ -38,41 +38,41 @@ class UsersTest < Test::Unit::TestCase
     end
 
     should "retrieve a list of spot urls the user has visited" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/visited_spots_urls', 'spots_urls.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/visited_spots_urls', 'spots_urls.json')
       spot_urls = @client.visited_spots_urls('sco')
       spot_urls.size.should == 22
       spot_urls.first.should == '/spots/682460'
     end
 
     should "retrieve a list of items the user is carrying" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/items?context=vault', 'items.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/items?context=vault', 'items.json')
       items = @client.user_items('sco', 'vault')
       items.first.issue_number.should == 27868
       items.first.name.should == 'Bowl of Noodles'
     end
 
     should "retrieve a list of friends for the user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/friends', 'users.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/friends', 'users.json')
       users = @client.friends('sco')
       users.first.first_name.should == 'Chalkbot'
     end
 
     should "retrieve a list of trips created by the user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/trips', 'trips.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/trips', 'trips.json')
       trips = @client.user_trips('sco')
       trips.first.name.should == 'London Pub Crawl'
       trips.first.spots.first.url.should == '/spots/164009'
     end
 
     should "retrieve a list of photos taken by the user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/photos', 'photos.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/photos', 'photos.json')
       photos = @client.user_photos('sco')
       #photos.first.type.should == 'photo'
       photos.first.photo_urls.square_50.should == 'http://static.gowalla.com/photos/912078_square_50.jpg'
     end
 
     should "retrieve a list of pins collected by the user" do
-      stub_get('http://pengwynn:0U812@api.gowalla.com/users/sco/pins', 'pins.json')
+      stub_get('https://pengwynn:0U812@api.gowalla.com/users/sco/pins', 'pins.json')
       pins = @client.user_pins('sco')
       pins.first.name.should == '110 Film'
       #pins.first.trip.type.should == 'challenge'


### PR DESCRIPTION
This commit protects login credentials with HTTPS (e.g., preventing username and password from being sent in plain text).

If there's anything else I need to do in order to make this a viable change for you to pull into the gem, just let me know.

Cheers,
Jason
