### PR TITLE
Relax hashie version dependency a bit to allow versions other than 1.0.0 to be used

### DIFF
--- a/gowalla.gemspec
+++ b/gowalla.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'faraday', '~> 0.7'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.7'
-  s.add_runtime_dependency 'hashie', '~> 1.0.0'
+  s.add_runtime_dependency 'hashie', '~> 1.0'
   s.add_runtime_dependency 'oauth2', '~> 0.4'
 
   s.add_development_dependency 'bundler', '~> 1.0'


### PR DESCRIPTION
Relax dependency on hashie to allow any version ~> 1.0, instead of 1.0.0

As hashie versions released since 1.0.0 have been 1.1.0 and 1.2.0 with trivial changes, this change should be sane.
